### PR TITLE
Use placeholder when image url is not provided

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -17,6 +17,8 @@ const mapDispatchToProps = (dispatch) => ({
     }),
 });
 
+const PLACEHOLDER_IMAGE_URL = process.env.PUBLIC_URL + "/placeholder.png";
+
 const ItemPreview = (props) => {
   const item = props.item;
 
@@ -36,7 +38,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || PLACEHOLDER_IMAGE_URL}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Description

A placeholder image is used when the item does not have an image_url associated with it.
<img width="1266" alt="Screenshot 2022-09-03 at 10 53 57" src="https://user-images.githubusercontent.com/32732980/188261661-242e941e-4c5f-4096-bb2c-eac325ba7542.png">

